### PR TITLE
feat(): add error on endpoints and tests associated to it

### DIFF
--- a/src/main/kotlin/com/example/FooController.kt
+++ b/src/main/kotlin/com/example/FooController.kt
@@ -1,8 +1,10 @@
 package com.example
 
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 
 @RestController
 @RequestMapping("/controller")
@@ -10,4 +12,7 @@ class FooController(private val repository: FooRepository) {
 
 	@GetMapping("/foo")
 	fun foo() = repository.foo()
+
+    @GetMapping("/foo/with/error")
+	fun fooWithError(): Nothing = throw ResponseStatusException(HttpStatus.NOT_FOUND, "No Foo found")
 }

--- a/src/main/kotlin/com/example/FooRouter.kt
+++ b/src/main/kotlin/com/example/FooRouter.kt
@@ -2,8 +2,11 @@ package com.example
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.reactive.function.server.ServerResponse.*
+import org.springframework.http.HttpStatus
+import org.springframework.web.reactive.function.server.ServerResponse.ok
 import org.springframework.web.reactive.function.server.router
+import org.springframework.web.server.ResponseStatusException
+import reactor.core.publisher.toMono
 
 @Configuration
 class FooRouter {
@@ -12,6 +15,7 @@ class FooRouter {
 	fun router(repository: FooRepository) = router {
 		"/router".nest {
 			GET("/foo") { ok().syncBody(repository.foo()) }
+            GET("/foo/with/error") { ResponseStatusException(HttpStatus.NOT_FOUND, "No Foo found").toMono() }
 		}
 	}
 }

--- a/src/test/kotlin/com/example/FooControllerTests.kt
+++ b/src/test/kotlin/com/example/FooControllerTests.kt
@@ -4,14 +4,17 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.web.reactive.error.ErrorWebFluxAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.reactive.server.WebTestClient
-import org.springframework.test.web.reactive.server.*
+import org.springframework.test.web.reactive.server.expectBody
 
 @RunWith(SpringRunner::class)
 @WebFluxTest
+@ImportAutoConfiguration(ErrorWebFluxAutoConfiguration::class)
 class FooControllerTests {
 
 	@Autowired
@@ -26,6 +29,15 @@ class FooControllerTests {
 		client.get().uri("/controller/foo").exchange()
 				.expectStatus().isOk
 				.expectBody<String>().isEqualTo("foo")
-
 	}
+
+    @Test
+    fun fooError() {
+        client
+                .get().uri("/controller/foo/with/error").exchange()
+                .expectStatus().isNotFound
+                .expectBody()
+                .jsonPath("$.message")
+                .isEqualTo("No Foo found")
+    }
 }

--- a/src/test/kotlin/com/example/FooIntegrationTests.kt
+++ b/src/test/kotlin/com/example/FooIntegrationTests.kt
@@ -7,7 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWeb
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.reactive.server.WebTestClient
-import org.springframework.test.web.reactive.server.*
+import org.springframework.test.web.reactive.server.expectBody
 
 @RunWith(SpringRunner::class)
 @SpringBootTest
@@ -24,10 +24,30 @@ class FooIntegrationTests {
 				.expectBody<String>().isEqualTo("foo")
 	}
 
+    @Test
+    fun fooControllerError() {
+        client
+                .get().uri("/controller/foo/with/error").exchange()
+                .expectStatus().isNotFound
+                .expectBody()
+                .jsonPath("$.message")
+                .isEqualTo("No Foo found")
+    }
+
 	@Test
 	fun fooRouterTest() {
 		client.get().uri("/router/foo").exchange()
 				.expectStatus().isOk
 				.expectBody<String>().isEqualTo("foo")
 	}
+
+    @Test
+    fun fooRouterError() {
+        client
+                .get().uri("/router/foo/with/error").exchange()
+                .expectStatus().isNotFound
+                .expectBody()
+                .jsonPath("$.message")
+                .isEqualTo("No Foo found")
+    }
 }

--- a/src/test/kotlin/com/example/FooRouterTests.kt
+++ b/src/test/kotlin/com/example/FooRouterTests.kt
@@ -4,16 +4,19 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.autoconfigure.web.reactive.error.ErrorWebFluxAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.reactive.server.WebTestClient
-import org.springframework.test.web.reactive.server.*
+import org.springframework.test.web.reactive.server.expectBody
 
 @RunWith(SpringRunner::class)
 @WebFluxTest
 @Import(FooRouter::class) // See https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-testing-spring-boot-applications-testing-autoconfigured-webflux-tests
+@ImportAutoConfiguration(ErrorWebFluxAutoConfiguration::class)
 class FooRouterTests {
 
 	@Autowired
@@ -32,4 +35,17 @@ class FooRouterTests {
 				.expectStatus().isOk
 				.expectBody<String>().isEqualTo("foo")
 	}
+
+    @Test
+    fun fooError() {
+        client
+                .get()
+                .uri("/router/foo/with/error")
+                .exchange()
+                .expectStatus().isNotFound
+                .expectBody()
+                .jsonPath("$.message")
+                .isEqualTo("No Foo found")
+    }
+
 }


### PR DESCRIPTION
This example provides a way to test errors on endpoints.  